### PR TITLE
change version

### DIFF
--- a/python/synse_plugin/__init__.py
+++ b/python/synse_plugin/__init__.py
@@ -6,7 +6,7 @@ from . import synse_pb2_grpc as grpc
 
 
 __title__ = 'synse_plugin'
-__version__ = '1.0.0'
+__version__ = '0.0.1'
 
 __description__ = 'Internal gRPC API for communication between plugins and Synse Server.'
 __author__ = 'Vapor IO'


### PR DESCRIPTION
while this is still all pre-release, I want to roll the version back down to 0.0.1 since it is still under development. this way the first release will be at 0.0.1. 

once this repo is ready for open sourcing, we can then make the version 1.0.0. until then, dev work should only increment the minor/micro version.