### PR TITLE
fix issue with CI release job dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,8 @@ workflows:
             tags:
               only: /^[0-9]*(\.[0-9]*)*$/
       - release:
+          requires:
+            - py-dist
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
preemptively fix a bug that will prevent tag runs (this was found and fixed in synse-sdk https://github.com/vapor-ware/synse-sdk/commit/ada24c57c85265d278cd8de73fbdb99bf1421898#diff-1d37e48f9ceff6d8030570cd36286a61)

basically, for a tag run to be triggered, all of the declared dependencies will need to have the same filters, which we don't want, so we will just remove the hard dependency. I *think* this should still work, since py-dist and release are isolated from the rest and don't share a workspace with them.. once this is in, I'll cut a new release and make sure everything runs happily here.