### PR TITLE
fix python packaging/distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ PKG_VER := $(shell python python/version.py)
 .PHONY: py-publish
 py-publish: ## Build and publish the python package to PyPi
 	pip install 'twine>=1.5.0'
-	python python/setup.py sdist bdist_wheel --universal
-	twine upload dist/*
-	rm -rf build dist .egg synse_plugin.egg-info
+	cd python ; python setup.py sdist bdist_wheel --universal
+	cd python ; twine upload dist/*
+	cd python ; rm -rf build dist .egg synse_plugin.egg-info
 
 .PHONY: version
 version:  ## Print the current version of Synse Server gRPC

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,7 +10,7 @@ description = 'Internal gRPC API for communication between plugins and Synse Ser
 url = 'https://github.com/vapor-ware/synse-server-grpc'
 email = 'vapor@vapor.io'
 author = 'Vapor IO'
-version = '0.0.2'
+version = '0.0.3'
 
 # packages required for this module to run
 required = [


### PR DESCRIPTION
apparantly when doing all the building/packaging, you have to be at the same level as setup.py for a distribution to actually be importable/work. tried this out and now it looks like i can install and import fine.